### PR TITLE
Rename air interpreter to avm

### DIFF
--- a/avm/client/README.md
+++ b/avm/client/README.md
@@ -1,5 +1,5 @@
-# Air interpreter
+# Aquamarine VM
 
-[![npm](https://img.shields.io/npm/v/@fluencelabs/air-interpreter)](https://www.npmjs.com/package/@fluencelabs/air-interpreter)
+[![npm](https://img.shields.io/npm/v/@fluencelabs/avm)](https://www.npmjs.com/package/@fluencelabs/avm)
 
-Aqua intermediary representation interpreter
+Aquamarine VM, runs AIR on peers

--- a/avm/client/build_wasm.ps1
+++ b/avm/client/build_wasm.ps1
@@ -1,8 +1,8 @@
 
 New-Item -ItemType Directory -Force -Path ./wasm
-wasm-pack build ../../air-interpreter --no-typescript --release -d wasm
+wasm-pack build ../../air-interpreter --no-typescript --release -d ../avm/client/wasm
 
-$base64string = [Convert]::ToBase64String([IO.File]::ReadAllBytes('./wasm/air_interpreter_client_bg.wasm'))
+$base64string = [Convert]::ToBase64String([IO.File]::ReadAllBytes('./avm/client/wasm/air_interpreter_client_bg.wasm'))
 
 $data = "// auto-generated
 

--- a/avm/client/package.json
+++ b/avm/client/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@fluencelabs/air-interpreter",
-    "description": "Aqua intermediary representation interpreter",
+    "name": "@fluencelabs/avm",
+    "description": "Aquamarine VM",
     "version": "0.0.0",
     "main": "./dist/index.js",
     "typings": "./dist/index.d.ts",


### PR DESCRIPTION
As I've discussed with @alari we should use air-interpreter only as a low-level concept and expose the whole package as `avm`

This PR renames the package from `air-interpreter` to `avm`